### PR TITLE
Fix recursing list and set of primitive types

### DIFF
--- a/lib/thrift/validator.rb
+++ b/lib/thrift/validator.rb
@@ -12,25 +12,29 @@ module Thrift
         when Types::STRUCT
           validate source.send(name)
         when Types::LIST, Types::SET
-          Array(source.send(name)).each do |item|
-            validate item
+          if recurse? field.fetch(:element)
+            Array(source.send(name)).each do |item|
+              validate item
+            end
           end
         when Types::MAP
-          key_field = field.fetch(:key)
-          if key_field[:class] && key_field[:class] < ::Thrift::Struct
+          if recurse? field.fetch(:key)
             Hash(source.send(name)).each_key do |key_value|
               validate key_value
             end
           end
 
-          value_field = field.fetch(:value)
-          if value_field[:class] && value_field[:class] < ::Thrift::Struct
+          if recurse? field.fetch(:value)
             Hash(source.send(name)).each_value do |value_value|
               validate value_value
             end
           end
         end
       end
+    end
+
+    def recurse?(field)
+      field[:class] && field[:class] < ::Thrift::Struct
     end
   end
 end

--- a/test.thrift
+++ b/test.thrift
@@ -13,6 +13,14 @@ struct ListExample {
   2: optional list<SimpleStruct> optional_list
 }
 
+struct StringListExample {
+  1: required list<string> required_list
+}
+
+struct StringSetExample {
+  1: required set<string> required_set
+}
+
 struct SetExample {
   1: required set<SimpleStruct> required_set
   2: optional set<SimpleStruct> optional_set

--- a/test/acceptance_test.rb
+++ b/test/acceptance_test.rb
@@ -46,6 +46,12 @@ class AcceptanceTest < MiniTest::Unit::TestCase
     assert_valid struct
   end
 
+  def test_passes_with_primitives_list
+    struct = StringListExample.new
+    struct.required_list = [ 'foo' ]
+    assert_valid struct
+  end
+
   def test_fails_if_a_nested_set_item_is_invalid
     struct = SetExample.new
     struct.required_set = Set.new([ SimpleStruct.new ])
@@ -63,6 +69,12 @@ class AcceptanceTest < MiniTest::Unit::TestCase
     struct = SetExample.new
     struct.required_set = Set.new([ SimpleStruct.new({ required_string: 'foo' }) ])
     struct.optional_set = Set.new([ SimpleStruct.new({ required_string: 'bar' }) ])
+    assert_valid struct
+  end
+
+  def test_passes_with_primitives_set
+    struct = StringSetExample.new
+    struct.required_set = Set.new([ 'foo' ])
     assert_valid struct
   end
 

--- a/vendor/gen-rb/test_types.rb
+++ b/vendor/gen-rb/test_types.rb
@@ -63,6 +63,40 @@ class ListExample
   ::Thrift::Struct.generate_accessors self
 end
 
+class StringListExample
+  include ::Thrift::Struct, ::Thrift::Struct_Union
+  REQUIRED_LIST = 1
+
+  FIELDS = {
+    REQUIRED_LIST => {:type => ::Thrift::Types::LIST, :name => 'required_list', :element => {:type => ::Thrift::Types::STRING}}
+  }
+
+  def struct_fields; FIELDS; end
+
+  def validate
+    raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field required_list is unset!') unless @required_list
+  end
+
+  ::Thrift::Struct.generate_accessors self
+end
+
+class StringSetExample
+  include ::Thrift::Struct, ::Thrift::Struct_Union
+  REQUIRED_SET = 1
+
+  FIELDS = {
+    REQUIRED_SET => {:type => ::Thrift::Types::SET, :name => 'required_set', :element => {:type => ::Thrift::Types::STRING}}
+  }
+
+  def struct_fields; FIELDS; end
+
+  def validate
+    raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field required_set is unset!') unless @required_set
+  end
+
+  ::Thrift::Struct.generate_accessors self
+end
+
 class SetExample
   include ::Thrift::Struct, ::Thrift::Struct_Union
   REQUIRED_SET = 1


### PR DESCRIPTION
When you had a list or set of a primitive type it tried to recurse and
validate which would fail. This makes sure it only recurses thrift
structs.
