### PR TITLE
Handle thrift unions correctly when recursing

### DIFF
--- a/lib/thrift/validator.rb
+++ b/lib/thrift/validator.rb
@@ -10,6 +10,7 @@ module Thrift
         type, name = field.fetch(:type), field.fetch(:name)
         case type
         when Types::STRUCT
+          next if source.kind_of?(Union) && source.get_set_field.to_s != name
           validate source.send(name)
         when Types::LIST, Types::SET
           if recurse? field.fetch(:element)

--- a/test.thrift
+++ b/test.thrift
@@ -35,3 +35,8 @@ struct MapValueExample {
   1: required map<string, SimpleStruct> required_map
   2: optional map<string, SimpleStruct> optional_map
 }
+
+union UnionExample {
+  1: SimpleStruct primary
+  2: string alternate
+}

--- a/test/acceptance_test.rb
+++ b/test/acceptance_test.rb
@@ -118,6 +118,13 @@ class AcceptanceTest < MiniTest::Unit::TestCase
     assert_valid struct
   end
 
+  def test_fails_if_no_union_fields_set
+    union = UnionExample.new
+    assert_raises(StandardError) do
+      Thrift::Validator.new.validate(union)
+    end
+  end
+
   def test_fails_if_union_set_field_is_invalid
     union = UnionExample.new
     union.primary = SimpleStruct.new

--- a/test/acceptance_test.rb
+++ b/test/acceptance_test.rb
@@ -118,6 +118,24 @@ class AcceptanceTest < MiniTest::Unit::TestCase
     assert_valid struct
   end
 
+  def test_fails_if_union_set_field_is_invalid
+    union = UnionExample.new
+    union.primary = SimpleStruct.new
+    refute_valid union
+  end
+
+  def test_passes_if_union_set_field_is_valid
+    union = UnionExample.new
+    union.primary = SimpleStruct.new required_string: 'foo'
+    assert_valid union
+  end
+
+  def test_passes_if_unions_alternate_value_is_provided
+    union = UnionExample.new
+    union.alternate = 'foo'
+    assert_valid union
+  end
+
   private
 
   def refute_valid(struct)

--- a/vendor/gen-rb/test_types.rb
+++ b/vendor/gen-rb/test_types.rb
@@ -154,3 +154,32 @@ class MapValueExample
   ::Thrift::Struct.generate_accessors self
 end
 
+class UnionExample < ::Thrift::Union
+  include ::Thrift::Struct_Union
+  class << self
+    def primary(val)
+      UnionExample.new(:primary, val)
+    end
+
+    def alternate(val)
+      UnionExample.new(:alternate, val)
+    end
+  end
+
+  PRIMARY = 1
+  ALTERNATE = 2
+
+  FIELDS = {
+    PRIMARY => {:type => ::Thrift::Types::STRUCT, :name => 'primary', :class => ::SimpleStruct},
+    ALTERNATE => {:type => ::Thrift::Types::STRING, :name => 'alternate'}
+  }
+
+  def struct_fields; FIELDS; end
+
+  def validate
+    raise(StandardError, 'Union fields are not set.') if get_set_field.nil? || get_value.nil?
+  end
+
+  ::Thrift::Union.generate_accessors self
+end
+


### PR DESCRIPTION
Union fields have the same `type` value as structs (`Types::STRUCT`), but they need to be handled differently:
The field should be validated _only_ if it is the one currently set in the union.

If a different field of the union is set, then the recursion should not continue into the not-set structures.
