### PR TITLE
Extend the exception message in Thrift::ProtocolException

### DIFF
--- a/lib/thrift/validator.rb
+++ b/lib/thrift/validator.rb
@@ -4,7 +4,12 @@ require 'thrift'
 module Thrift
   class Validator
     def validate(source)
-      source.validate
+      begin
+        source.validate
+      rescue Thrift::ProtocolException => ex
+        message = "#{source.class.name}: #{ex}"
+        raise Thrift::ProtocolException.new(ex.type, message)
+      end
 
       source.struct_fields.each_pair do |_, field|
         type, name = field.fetch(:type), field.fetch(:name)

--- a/test/exceptions_test.rb
+++ b/test/exceptions_test.rb
@@ -1,0 +1,25 @@
+require_relative 'test_helper'
+
+class ExceptionsTest < MiniTest::Unit::TestCase
+  def test_exception_message_contains_class_name
+    # The error is in NestedExample - required_struct is unset
+    struct = NestedExample.new required_struct: nil
+
+    ex = assert_raises Thrift::ProtocolException do
+      Thrift::Validator.new.validate(struct)
+    end
+    assert_match /NestedExample/, ex.message
+  end
+
+  def test_exception_message_contains_nested_class_name
+    # Here NestedExample is valid, but the error is one level down
+    # in SimpleStruct (its required_string is unset)
+    struct = NestedExample.new
+    struct.required_struct = SimpleStruct.new required_string: nil
+
+    ex = assert_raises Thrift::ProtocolException do
+      Thrift::Validator.new.validate(struct)
+    end
+    assert_match /SimpleStruct/, ex.message
+  end
+end


### PR DESCRIPTION
When working with thrift structs in test data, I could sometimes use a more helpful exception message.

Especially for nested structs, when I see:

```
Required field id is unset!
```

...this is not telling me much. I have `id` in the nested structs as well. Which one is missing the `id`?

I propose to extend the message coming with a `Thrift::ProtocolException`. Let me know what you think.

```
# Before
Thrift::ProtocolException: Required field required_string is unset!

# After
Thrift::ProtocolException: SimpleStruct: Required field required_string is unset!
```
